### PR TITLE
Add first step to resolve common issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,19 @@ If you are running MacOS 13 (Ventura), the JetBrains Client may be blocked by OS
 
 If you see the above message while attempting to connect to a codespace via the JetBrains Gateway or any compatible JetBrains IDE, you can follow these steps to resolve the issue:
 
-1. Open `System Preferences` and navigate to `Privacy & Security`
+1. Click `Cancel`
+
+2. Open `System Preferences` and navigate to `Privacy & Security`
 
 ![Screenshot 2022-11-08 at 11 09 46](https://user-images.githubusercontent.com/4679612/200692779-12131d82-ddb7-411d-8826-ceaa39887079.png)
 
-2. Scroll down until you see the message about the JetBrains Client being blocked
+3. Scroll down until you see the message about the JetBrains Client being blocked
 
 ![Screenshot 2022-11-08 at 11 09 54](https://user-images.githubusercontent.com/4679612/200692894-cb6c32f4-ff0d-4e1d-8906-269a84a62c85.png)
 
-3. Click `Open Anyway`
+4. Click `Open Anyway`
 
-4. Connect to your codespace
+5. Connect to your codespace
 
 **Note:** On the first connection after allowing the JetBrains Client, you may see the following warning:
 ![image (1)](https://user-images.githubusercontent.com/4679612/200693247-c46774e1-261e-447f-991c-353f9aff4a77.png)


### PR DESCRIPTION
Added a minor first step to resolve the Ventura issue. The message about the JetBrains Client being blocked does not appear until `Cancel` is clicked.